### PR TITLE
Updating to ROOT v6

### DIFF
--- a/datamodel/CMakeLists.txt
+++ b/datamodel/CMakeLists.txt
@@ -21,3 +21,9 @@ install(TARGETS datamodel
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
   PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/datamodel"
     COMPONENT dev)
+
+if (${ROOT_VERSION} GREATER 6)
+  install(FILES
+      "${PROJECT_BINARY_DIR}/datamodel/ExampleDict_rdict.pcm"
+      DESTINATION "${INSTALL_LIB_DIR}" COMPONENT dev)
+endif()

--- a/init.sh
+++ b/init.sh
@@ -1,6 +1,6 @@
 export PATH=/afs/cern.ch/sw/lcg/contrib/CMake/2.8.9/Linux-i386/bin:${PATH}
-source /afs/cern.ch/sw/lcg/contrib/gcc/4.8.1/x86_64-slc6/setup.sh
-source /afs/cern.ch/sw/lcg/app/releases/ROOT/5.34.20/x86_64-slc6-gcc48-opt/root/bin/thisroot.sh
+source /afs/cern.ch/sw/lcg/contrib/gcc/4.9.3/x86_64-slc6/setup.sh
+source /afs/cern.ch/exp/fcc/sw/0.5/LCG_80/ROOT/6.04.06/x86_64-slc6-gcc49-opt/bin/thisroot.sh
 
 export FCCEDM=$PWD/install
 export LD_LIBRARY_PATH=$FCCEDM/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Updated the init.sh script to use GCC / ROOT versions as used currently in FCCSW. Added generated PCM dictionary as install target (with a check on the detected ROOT version).
