### PR TITLE
Updating track model

### DIFF
--- a/edm.yaml
+++ b/edm.yaml
@@ -191,13 +191,13 @@ datatypes :
     OneToManyRelations :
      - fcc::CaloHit hits // Hits used in the cluster
 
- fcc::TrackState:
+  fcc::TrackState:
     Description: "Track state at a given point on the track."
     Author : "C. Bernet, B. Hegner"
     Members:
      - float[6] trackParameters // track parameters consisting of five local coordinates describing the track and time information  
      - float[6][6] covariance // the covariance matrix of the track parameters
-     OneToOneRelations:
+    OneToOneRelations :
      - fcc::TrackCluster cluster // the belonging measurement      
 
   fcc::PerigeeTrackState:
@@ -218,8 +218,8 @@ datatypes :
      - float chi2 // chi2 returned by the track fit
      - unsigned ndf // Number of degrees of freedom of the track fit
      - unsigned bits // Stores flags
-    OneToOneRelation:
-     - fcc::PerigeeTrackState // the track state at the beamline
+    OneToOneRelations :
+     - fcc::PerigeeTrackState perigee// the track state at the beamline
     OneToManyRelations :
      - fcc::TrackState states // states along the track
 

--- a/edm.yaml
+++ b/edm.yaml
@@ -193,30 +193,21 @@ datatypes :
 
   fcc::TrackState:
     Description: "Track state at a given point on the track. The track parameters are chosen 
-    to be decribed in the curvilinear frame of the track. With the track parameters 
-    (local1:=0,local2:=0,phi,theta,q/p) defined at the origin of a surface perpendicular to 
-    the track. The local coordinates are zero per defintion. The azimuthal and polar angle
-    can be calculated from the direction of the momentum. The last parameter q/p can be 
-    calculated from the charge and the value of the momentum."
-    Author : "C. Bernet, B. Hegner"
-    Members:
-     - fcc::Point position // global position specifying the location on the track  
-     - float[3] momentum   // the momentum at position  
-     - float charge        // the charge
-     - float[15] cov       // the covariance matrix describing the covariances of the five 
-       		           // track parameters. Duplicated entries have been left out, which 
-		           // reduces thesize to 15 entries      
-
-  fcc::PerigeeTrackState:
-    Description: "Track state at the beamline."
-    Author : "C. Bernet, B. Hegner"
+    to be decribed in the curvilinear frame of the track. The azimuthal and polar angle
+    describe the direction of the momentum. The bending direction and the momentum are described by q/p. 
+    In case it is the first track state at the beamline the impact parameters and their reference point
+    need to be specified. The covariance matrix describes the covariances of the five track parameters.
+    Duplicated entries have been left out, which reduces the size to 15 entries."
+    Author : "J. Hrdinka"
     Members:
      - float phi // azimuthal angle describing the direction of the momentum
      - float theta // polar angle describing the direction of the momentum
-     - float qOverP // describing the curvature, bending direction and momentum 
+     - float qOverP // describing the curvature, bending direction and momentum
      - float d0 // Transverse impact parameter
      - float z0 // Longitudinal impact parameter
      - fcc::Point referencePoint // Point from which d0, z0 are measured
+     - std::array<float,15> cov // the covariance matrix of the track parameters 
+                                     
 
   fcc::Track:
     Description: "Track reconstructed from clusters in the inner tracker"
@@ -225,11 +216,9 @@ datatypes :
      - float chi2 // chi2 returned by the track fit
      - unsigned ndf // Number of degrees of freedom of the track fit
      - unsigned bits // Stores flags
-    OneToOneRelations :
-     - fcc::PerigeeTrackState perigee // track state at the beamline
     OneToManyRelations :
      - fcc::TrackCluster clusters // Clusters used for reconstruction
-     - fcc::TrackState states // states along the track
+     - fcc::TrackState states // states along the track. The first state is taken at the point of closest approach.
 
   fcc::WeightedTrack:
     Description: "A track associated to a vertex with its weight."

--- a/edm.yaml
+++ b/edm.yaml
@@ -192,16 +192,23 @@ datatypes :
      - fcc::CaloHit hits // Hits used in the cluster
 
   fcc::TrackState:
-    Description: "Track state at a given point on the track."
+    Description: "Track state at a given point on the track. The track parameters are chosen 
+    to be decribed in the curvilinear frame of the track. With the track parameters 
+    (local1:=0,local2:=0,phi,theta,q/p) defined at the origin of a surface perpendicular to 
+    the track. The local coordinates are zero per defintion. The azimuthal and polar angle
+    can be calculated from the direction of the momentum. The last parameter q/p can be 
+    calculated from the charge and the value of the momentum."
     Author : "C. Bernet, B. Hegner"
     Members:
-     - float[6] trackParameters // track parameters consisting of five local coordinates describing the track and time information  
-     - float[6][6] covariance // the covariance matrix of the track parameters
-    OneToOneRelations :
-     - fcc::TrackCluster cluster // the belonging measurement      
+     - fcc::Point position // global position specifying the location on the track  
+     - float[3] momentum   // the momentum at position  
+     - float charge        // the charge
+     - float[15] cov       // the covariance matrix describing the covariances of the five 
+       		           // track parameters. Duplicated entries have been left out, which 
+		           // reduces thesize to 15 entries      
 
   fcc::PerigeeTrackState:
-    Description: "Track state at a given point on the track in perigee representation."
+    Description: "Track state at the beamline."
     Author : "C. Bernet, B. Hegner"
     Members:
      - float phi // azimuthal angle describing the direction of the momentum
@@ -219,8 +226,9 @@ datatypes :
      - unsigned ndf // Number of degrees of freedom of the track fit
      - unsigned bits // Stores flags
     OneToOneRelations :
-     - fcc::PerigeeTrackState perigee// the track state at the beamline
+     - fcc::PerigeeTrackState perigee // track state at the beamline
     OneToManyRelations :
+     - fcc::TrackCluster clusters // Clusters used for reconstruction
      - fcc::TrackState states // states along the track
 
   fcc::WeightedTrack:

--- a/edm.yaml
+++ b/edm.yaml
@@ -191,24 +191,36 @@ datatypes :
     OneToManyRelations :
      - fcc::CaloHit hits // Hits used in the cluster
 
-  fcc::TrackState:
+ fcc::TrackState:
     Description: "Track state at a given point on the track."
     Author : "C. Bernet, B. Hegner"
     Members:
-     - float location // Location on the track. (Radius?)
-     - float omega // Track curvature in cm.
+     - float[6] trackParameters // track parameters consisting of five local coordinates describing the track and time information  
+     - float[6][6] covariance // the covariance matrix of the track parameters
+     OneToOneRelations:
+     - fcc::TrackCluster cluster // the belonging measurement      
+
+  fcc::PerigeeTrackState:
+    Description: "Track state at a given point on the track in perigee representation."
+    Author : "C. Bernet, B. Hegner"
+    Members:
+     - float phi // azimuthal angle describing the direction of the momentum
+     - float theta // polar angle describing the direction of the momentum
+     - float qOverP // describing the curvature, bending direction and momentum 
      - float d0 // Transverse impact parameter
      - float z0 // Longitudinal impact parameter
+     - fcc::Point referencePoint // Point from which d0, z0 are measured
 
   fcc::Track:
     Description: "Track reconstructed from clusters in the inner tracker"
     Author : "C. Bernet, B. Hegner"
-    Members:
+    Members:     
      - float chi2 // chi2 returned by the track fit
      - unsigned ndf // Number of degrees of freedom of the track fit
      - unsigned bits // Stores flags
+    OneToOneRelation:
+     - fcc::PerigeeTrackState // the track state at the beamline
     OneToManyRelations :
-     - fcc::TrackCluster clusters // Clusters used for reconstruction
      - fcc::TrackState states // states along the track
 
   fcc::WeightedTrack:


### PR DESCRIPTION
Following discussions within FCCSW and ACTS about updating the Track EDM. Here is the proposal for the Update:
The **TrackState** has 5 local(*) track parameters (two local coordinates on the surface, phi, theta, q/p) + one coordinate for time information and the corresponding covariance matrix. This **_TrackState** should be bound to its corresponding **TrackCluster** (measurement) by a _OneToOneRelation_. In this way the corresponding surface can be accessed(**) and the local _chi^2_ can be calculated. Therefore the _OneToManyRelation_ to **TrackClusters** in the **Track** is obsolete.
For the perigee representation (_TrackState_ at the beam line) a new type has been introduced since the track parameters differ from the usual _TrackState_: **PerigeeTrackState**. Accordingly a _OneToOneRelation_ to the _Track_ has been added.

(*) in respect to its measurement surface
(**) In the next iteration a convenience method will be introduced which allows to access the corresponding surface identification of the `TrackCluster` over its `TrackHits` via the cellID of the `TrackHits`