### PR TITLE
Digi Adaptions to PositionedTrackHit 

### DIFF
--- a/edm.yaml
+++ b/edm.yaml
@@ -170,9 +170,11 @@ datatypes :
 
   fcc::PositionedTrackHit:
     Description: "A track hit and with its global position"
-    Author: "J. Lingemann, B. Hegner"
+    Author: "J. Lingemann, B. Hegner, J. Hrdinka"
     Members:
      - fcc::Point position // The global position
+     - float length // The length of the hit (distance between pre and post step)
+     - std::array<float,3> direction // The direction of the hit
      - fcc::BareHit core // The hit
 
   fcc::CaloHitMCParticleAssociation:

--- a/edm.yaml
+++ b/edm.yaml
@@ -18,6 +18,10 @@ components:
     x : float
     y : float
     z : float
+  
+  fcc::StepPoints:
+    preStep : fcc::Point
+    postStep : fcc::Point
 
   # really need to expose some function f(Cellid) -> position
   fcc::BareHit:
@@ -169,12 +173,10 @@ datatypes :
      - fcc::BareHit core // The hit
 
   fcc::PositionedTrackHit:
-    Description: "A track hit and with its global position"
+    Description: "A track hit and with its global pre and post step positions."
     Author: "J. Lingemann, B. Hegner, J. Hrdinka"
     Members:
-     - fcc::Point position // The global position
-     - float length // The length of the hit (distance between pre and post step)
-     - std::array<float,3> direction // The direction of the hit
+     - fcc::StepPoints positions // The pre and post step points in global frame
      - fcc::BareHit core // The hit
 
   fcc::CaloHitMCParticleAssociation:


### PR DESCRIPTION
In order to digitize a simulated hit in a tracker, not only the position but also the intervall in which the energy was deposited needs to known. This intervall can be either described by a pre and post step point or by giving the position, the length and direction of the hit. The [DD4hep hit](http://ilcsoft.desy.de/v01-17-09/DD4hep/v00-15/doc/html/class_d_d4hep_1_1_simulation_1_1_geant4_tracker_hit.html) is implemented using the second possibility, hence, this way was chosen for the implementation.
The PositionedTrackerHit which already consists of a position was extended by a length and a direction.