### PR TITLE
Add weight and no. of pileups to EventInfo

### DIFF
--- a/edm.yaml
+++ b/edm.yaml
@@ -53,12 +53,9 @@ datatypes :
     Author : "C. Bernet, B. Hegner"
     Members :
      - int number // Event number
+     - int currentpileup // Number of pileup collisions in this event
+     - float weight // Event weight
 
-  fcc::FloatValue :
-    Description : "Contains float"
-    Author : "M. Selvaggi"
-    Members :
-     - float value // The actual float value
 
   fcc::Particle :
     Description : "Reconstructed particle"

--- a/edm.yaml
+++ b/edm.yaml
@@ -55,7 +55,12 @@ datatypes :
      - int number // Event number
      - int currentpileup // Number of pileup collisions in this event
      - float weight // Event weight
-
+     
+  fcc::FloatValue :
+    Description : "Contains float"
+    Author : "M. Selvaggi"
+    Members :
+     - float value // The actual float value
 
   fcc::Particle :
     Description : "Reconstructed particle"


### PR DESCRIPTION
Since the header collision on MacOs anyway forces us to make backwards-compatible breaking changes, it might as well be done properly. The only application of the `FloatValue` currently is in EventWeights, so I propose to substitute it with a proper member of `EventInfo`.

This PR requires two changes to FCCSW in the Delphes and Pythia Interfaces.
The number of pileup is added as well to the eventinformation