### PR TITLE
DataFrame Utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -DDROP_CGAL ${CPP_STANDARD_FLAGS} 
 #--- Declare ROOT dependency ---------------------------------------------------
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-find_package(ROOT REQUIRED COMPONENTS RIO Tree Physics ROOTDataFrame ROOTVecOps)
+find_package(ROOT REQUIRED COMPONENTS RIO Tree Physics) # TODO: Add  ROOTDataFrame ROOTVecOps as ROOT 6.16 available
 include_directories(${ROOT_INCLUDE_DIR})
 include(${ROOT_USE_FILE})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ foreach(p LIB BIN INCLUDE CMAKE)
 endforeach()
 
 # Set up C++14
-set(CMAKE_CXX_STANDARD 14)
+option(CMAKE_CXX_STANDARD "C++ standard" 14)
 if (${APPLE})
     set(CPP_STANDARD_FLAGS "-std=c++14\ -stdlib=libc++")
 endif()
@@ -57,7 +57,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -DDROP_CGAL ${CPP_STANDARD_FLAGS} 
 #--- Declare ROOT dependency ---------------------------------------------------
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-find_package(ROOT REQUIRED COMPONENTS RIO Tree Physics)
+find_package(ROOT REQUIRED COMPONENTS RIO Tree Physics ROOTDataFrame ROOTVecOps)
 include_directories(${ROOT_INCLUDE_DIR})
 include(${ROOT_USE_FILE})
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,5 @@
+# TODO: re-enable dataframe test as root 6.16 is available
+
 include_directories(
         ${CMAKE_SOURCE_DIR}/datamodel
 )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,19 +3,19 @@ include_directories(
 )
 
 add_executable(fccedm-write write.cc)
-add_executable(fccedm-dataframe dataframe.cc)
+#add_executable(fccedm-dataframe dataframe.cc)
 add_executable(fccedm-read read.cc)
 add_executable(fccedm-simplewrite simplewrite.cc)
 add_executable(fccedm-simpleread simpleread.cc)
 add_executable(fccedm-graph graph.cc)
 
 target_link_libraries(fccedm-write utilities datamodel podio datamodelDict)
-target_link_libraries(fccedm-dataframe utilities datamodel podio datamodelDict ROOT::ROOTDataFrame)
+#target_link_libraries(fccedm-dataframe utilities datamodel podio datamodelDict ROOT::ROOTDataFrame)
 target_link_libraries(fccedm-read utilities datamodel podio datamodelDict )
 target_link_libraries(fccedm-simplewrite utilities datamodel podio datamodelDict )
 target_link_libraries(fccedm-simpleread utilities datamodel podio datamodelDict )
 target_link_libraries(fccedm-graph utilities)
-install(TARGETS fccedm-write fccedm-read fccedm-simplewrite fccedm-simpleread fccedm-dataframe
+install(TARGETS fccedm-write fccedm-read fccedm-simplewrite fccedm-simpleread #fccedm-dataframe
   # IMPORTANT: Add the write executable to the "export-set"
   EXPORT fccedmTargets
   RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin)
@@ -35,6 +35,6 @@ set_property(TEST fccedm-write PROPERTY ENVIRONMENT LD_LIBRARY_PATH=$ENV{PODIO}/
 add_test(NAME fccedm-read COMMAND fccedm-read DEPENDS fccedm-write)
 set_property(TEST fccedm-read PROPERTY ENVIRONMENT LD_LIBRARY_PATH=$ENV{PODIO}/lib:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/examples:$ENV{LD_LIBRARY_PATH})
 
-add_test(NAME fccedm-dataframe COMMAND fccedm-dataframe DEPENDS fccedm-write)
-set_property(TEST fccedm-dataframe PROPERTY ENVIRONMENT LD_LIBRARY_PATH=$ENV{PODIO}/lib:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/examples:$ENV{LD_LIBRARY_PATH})
+#add_test(NAME fccedm-dataframe COMMAND fccedm-dataframe DEPENDS fccedm-write)
+#set_property(TEST fccedm-dataframe PROPERTY ENVIRONMENT LD_LIBRARY_PATH=$ENV{PODIO}/lib:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/examples:$ENV{LD_LIBRARY_PATH})
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,20 +3,23 @@ include_directories(
 )
 
 add_executable(fccedm-write write.cc)
+add_executable(fccedm-dataframe dataframe.cc)
 add_executable(fccedm-read read.cc)
 add_executable(fccedm-simplewrite simplewrite.cc)
 add_executable(fccedm-simpleread simpleread.cc)
 add_executable(fccedm-graph graph.cc)
 
 target_link_libraries(fccedm-write utilities datamodel podio datamodelDict)
+target_link_libraries(fccedm-dataframe utilities datamodel podio datamodelDict ROOT::ROOTDataFrame)
 target_link_libraries(fccedm-read utilities datamodel podio datamodelDict )
 target_link_libraries(fccedm-simplewrite utilities datamodel podio datamodelDict )
 target_link_libraries(fccedm-simpleread utilities datamodel podio datamodelDict )
 target_link_libraries(fccedm-graph utilities)
-install(TARGETS fccedm-write fccedm-read fccedm-simplewrite fccedm-simpleread
+install(TARGETS fccedm-write fccedm-read fccedm-simplewrite fccedm-simpleread fccedm-dataframe
   # IMPORTANT: Add the write executable to the "export-set"
   EXPORT fccedmTargets
   RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin)
+
 
 
 # --- adding tests for examples ------------------------------
@@ -31,3 +34,7 @@ set_property(TEST fccedm-write PROPERTY ENVIRONMENT LD_LIBRARY_PATH=$ENV{PODIO}/
 
 add_test(NAME fccedm-read COMMAND fccedm-read DEPENDS fccedm-write)
 set_property(TEST fccedm-read PROPERTY ENVIRONMENT LD_LIBRARY_PATH=$ENV{PODIO}/lib:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/examples:$ENV{LD_LIBRARY_PATH})
+
+add_test(NAME fccedm-dataframe COMMAND fccedm-dataframe DEPENDS fccedm-write)
+set_property(TEST fccedm-dataframe PROPERTY ENVIRONMENT LD_LIBRARY_PATH=$ENV{PODIO}/lib:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/examples:$ENV{LD_LIBRARY_PATH})
+

--- a/examples/dataframe.cc
+++ b/examples/dataframe.cc
@@ -1,0 +1,63 @@
+
+#include <ROOT/RDataFrame.hxx>
+#include <TSystem.h>
+#include <TLorentzVector.h>
+
+// FCC event datamodel includes
+#include "datamodel/ParticleData.h"
+// pt lambda defined here
+#include "utilities/FCCLambdas.h"
+
+
+#include <algorithm>
+
+
+std::vector<float> particle_eta(std::vector<fcc::ParticleData> in){
+ std::vector<float> result;
+   TLorentzVector lv;
+	 for (size_t i = 0; i < in.size(); ++i) {
+     lv.SetXYZM(in[i].core.p4.px, in[i].core.p4.py, in[i].core.p4.pz, in[i].core.p4.mass);
+		 result.push_back(lv.Eta());
+	 }
+	 return result;
+}
+
+  bool eta_filter (std::vector<float> in) { return (*std::max_element(in.begin(),
+  in.end()) > 3); }
+
+int main(){
+
+   // fcc edm libraries
+   gSystem->Load("libutilities.so");
+   gSystem->Load("libdatamodel.so");
+   
+
+   std::cout << "Read file.. ";
+
+   
+   std::cout << "Creating TDataFrame ..." << std::endl;
+   ROOT::RDataFrame df("events", "example.root");
+
+
+
+   auto dff =  df
+                      .Define("GenParticle_eta", particle_eta, {"GenParticle"})
+                    ;
+  auto nentries = dff.Count();
+  std::cout << "Count events: " <<  *nentries << std::endl;
+
+
+  auto dff_filtered = dff.Filter(eta_filter, {"GenParticle_eta"});
+  auto nentries_filtered = dff_filtered.Count();
+  std::cout << " ... events with at least one particle with eta > 3: " <<  *nentries_filtered << std::endl;
+
+  std::cout << "Writing snapshot  ..." << std::endl;
+  dff.Snapshot("events", "example_snapshot.root",
+    { 
+      "GenParticle_eta",
+
+      }
+    );
+
+   return 0;
+}

--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -5,7 +5,10 @@ include_directories(
 file(GLOB sources *.cc)
 file(GLOB headers *.h)
 
-add_library(utilities SHARED ${sources} ${headers} )
+include_directories(${CMAKE_SOURCE_DIR}/utilities)
+ROOT_GENERATE_DICTIONARY(G__utilities FCCLambdas.h LINKDEF LinkDef.h)
+
+add_library(utilities SHARED ${sources} ${headers} G__utilities.cxx )
 target_link_libraries(utilities datamodel podio ROOT::Physics)
 
 set_target_properties(utilities PROPERTIES
@@ -18,3 +21,13 @@ install(TARGETS utilities
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
   PUBLIC_HEADER DESTINATION "${INSTALL_INCLUDE_DIR}/utilities"
     COMPONENT dev)
+
+install(FILES
+  "${PROJECT_BINARY_DIR}/utilities/libutilities.rootmap"
+  DESTINATION "${INSTALL_LIB_DIR}" COMPONENT dev)
+
+if (${ROOT_VERSION} GREATER 6)
+  install(FILES
+      "${PROJECT_BINARY_DIR}/utilities/libutilities_rdict.pcm"
+      DESTINATION "${INSTALL_LIB_DIR}" COMPONENT dev)
+endif()

--- a/utilities/FCCLambdas.cc
+++ b/utilities/FCCLambdas.cc
@@ -1,0 +1,51 @@
+#include "FCCLambdas.h"
+
+#include "TLorentzVector.h"
+#include "datamodel/MCParticleData.h"
+#include "datamodel/Point.h"
+#include "datamodel/LorentzVector.h"
+
+std::vector<float> pt (std::vector<fcc::MCParticleData> in){
+ std::vector<float> result;
+	 for (size_t i = 0; i < in.size(); ++i) {
+		 result.push_back(std::sqrt(in[i].core.p4.px * in[i].core.p4.px + in[i].core.p4.py * in[i].core.p4.py));
+	 }
+	 return result;
+}
+
+std::vector<float> eta(std::vector<fcc::MCParticleData> in){
+ std::vector<float> result;
+   TLorentzVector lv;
+	 for (size_t i = 0; i < in.size(); ++i) {
+     lv.SetXYZM(in[i].core.p4.px, in[i].core.p4.py, in[i].core.p4.pz, in[i].core.p4.mass);
+		 result.push_back(lv.Eta());
+	 }
+	 return result;
+}
+
+std::vector<TLorentzVector> tlv(std::vector<fcc::LorentzVector> in){
+ std::vector<TLorentzVector> result;
+   TLorentzVector lv;
+	 for (size_t i = 0; i < in.size(); ++i) {
+     lv.SetXYZM(in[i].px, in[i].py, in[i].pz, in[i].mass);
+		 result.push_back(lv);
+	 }
+	 return result;
+}
+
+std::vector<float> r (std::vector<fcc::Point> in) {
+ std::vector<float> result;
+	 for (size_t i = 0; i < in.size(); ++i) {
+     result.push_back(std::sqrt(in[i].x*in[i].x + in[i].y*in[i].y));
+   }
+ return result; 
+}
+
+
+std::vector<float> norm (std::vector<fcc::Point> in) {
+ std::vector<float> result;
+	 for (size_t i = 0; i < in.size(); ++i) {
+     result.push_back(std::sqrt(in[i].x*in[i].x + in[i].y*in[i].y + in[i].z*in[i].z));
+   }
+ return result; 
+}

--- a/utilities/FCCLambdas.h
+++ b/utilities/FCCLambdas.h
@@ -1,0 +1,32 @@
+
+#ifndef  FCC_UTILITYLAMBDAS_H
+#define  FCC_UTILITYLAMBDAS_H
+
+#include <cmath>
+#include <vector>
+
+class TLorentzVector;
+
+namespace fcc {
+  class Point;
+  class LorentzVector;
+
+  class MCParticleData;
+}
+
+/// good luck charm against segfaults
+fcc::MCParticleData __magicParticle();
+
+std::vector<float> pt (std::vector<fcc::MCParticleData> in);
+
+
+std::vector<float> eta(std::vector<fcc::MCParticleData> in);
+
+std::vector<TLorentzVector> tlv(std::vector<fcc::LorentzVector> in);
+
+std::vector<float> r (std::vector<fcc::Point> in); 
+
+std::vector<float> r (std::vector<fcc::Point> in); 
+
+
+#endif

--- a/utilities/LinkDef.h
+++ b/utilities/LinkDef.h
@@ -1,0 +1,11 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ nestedclasses;
+
+
+#pragma link C++ function pt;
+#pragma link C++ function eta;
+#endif


### PR DESCRIPTION
Few convenience functions often used on the command line, allows to write code like

```
~/$ root 
root [0]   gSystem->Load("libutilities");
root [1] ROOT::RDataFrame dd("events", "output.root")
root [2] d = dd.Define("gen_pt", pt, {"GenParticles"})
root [3] h = d.Histo1D("gen_pt")
root [4] h->Draw():
```

Also includes a test/example. I would also propose to rename the libraries to something more fcc specific ("libFCCdatamodel.so"?) in a future PR.
