### PR TITLE
Add support for C++ 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,15 @@ foreach(p LIB BIN INCLUDE CMAKE)
   endif()
 endforeach()
 
-# Set up C++14
-set(CMAKE_CXX_STANDARD 14)
+# Set up C++ Standard
+set(CMAKE_CXX_STANDARD 14 CACHE STRING "")
+
+if(NOT CMAKE_CXX_STANDARD MATCHES "14|17")
+  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
+endif()
+
 if (${APPLE})
-    set(CPP_STANDARD_FLAGS "-std=c++14\ -stdlib=libc++")
+    set(CPP_STANDARD_FLAGS "-std=c++${CMAKE_CXX_STANDARD}\ -stdlib=libc++")
 endif()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -DDROP_CGAL ${CPP_STANDARD_FLAGS} -Wall -Wextra -Wpedantic -Wno-unused-variable -Wno-unused-parameter")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@ if(NOT CMAKE_CXX_STANDARD MATCHES "14|17")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 
+message (STATUS "C++ standard: ${CMAKE_CXX_STANDARD}")
+
 if (${APPLE})
     set(CPP_STANDARD_FLAGS "-std=c++${CMAKE_CXX_STANDARD}\ -stdlib=libc++")
 endif()


### PR DESCRIPTION
- Keep C++14 as the default standard
- User can modify the C++ Standard by defining `CMAKE_CXX_STANDARD`, which overrides the default value
- Restrict values to '14' or '17'
- Print status message with the chosen cxx standard 