### PR TITLE
Add dictionary for FloatData

### DIFF
--- a/utilities/CMakeLists.txt
+++ b/utilities/CMakeLists.txt
@@ -6,7 +6,7 @@ file(GLOB sources *.cc)
 file(GLOB headers *.h)
 
 include_directories(${CMAKE_SOURCE_DIR}/utilities)
-ROOT_GENERATE_DICTIONARY(G__utilities FCCLambdas.h LINKDEF LinkDef.h)
+ROOT_GENERATE_DICTIONARY(G__utilities FloatData.h FCCLambdas.h LINKDEF LinkDef.h)
 
 add_library(utilities SHARED ${sources} ${headers} G__utilities.cxx )
 target_link_libraries(utilities datamodel podio::podioRootIO ROOT::Physics)

--- a/utilities/FloatData.h
+++ b/utilities/FloatData.h
@@ -1,0 +1,19 @@
+#ifndef DATAMODEL_FloatDATA_H
+#define DATAMODEL_FloatDATA_H
+
+
+
+namespace fcc {
+/** @class FloatData
+ *  Contains float
+ *  @author: M. Selvaggi
+ */
+
+class FloatData {
+public:
+  float value;  ///< The actual float value
+};
+} // namespace fcc
+
+#endif
+

--- a/utilities/LinkDef.h
+++ b/utilities/LinkDef.h
@@ -8,4 +8,6 @@
 
 #pragma link C++ function pt;
 #pragma link C++ function eta;
+#pragma link C++ class fcc::FloatData+;
+#pragma link C++ class std::vector<fcc::FloatData>+;
 #endif


### PR DESCRIPTION
This should allow to use legacy root files (in RDataFrame, not in heppy) without needing fcc-edm-legacy.